### PR TITLE
Shelf and bin suggestions

### DIFF
--- a/contracts/LostAndFound.cdc
+++ b/contracts/LostAndFound.cdc
@@ -161,7 +161,8 @@ pub contract LostAndFound {
     // It groups bins by type to help make discovery of the assets that a
     // redeeming address can claim. 
     pub resource Shelf {
-        access(self) let bins: @{String: Bin}   //TODO: soon Type can be used as key, get rid of identifierToType
+        //TODO: soon Type can be used as key, get rid of identifierToType
+        access(self) let bins: @{String: Bin}   
         access(self) let identifierToType: {String: Type}
         access(self) let redeemer: Address
 
@@ -201,13 +202,12 @@ pub contract LostAndFound {
                 // no bin, make a new one and insert it
                 let oldValue <- self.bins.insert(key: type.identifier, <- create Bin(type: type))
                 destroy oldValue
-
                 // add this mapping of type to identifier
                 self.identifierToType[type.identifier] = type
             }
 
-            let binPublic = self.borrowBin(type: type)!
-            binPublic.deposit(ticket: <-ticket)
+            let bin = self.borrowBin(type: type)!
+            bin.deposit(ticket: <-ticket)
         }
 
 

--- a/contracts/LostAndFound.cdc
+++ b/contracts/LostAndFound.cdc
@@ -228,7 +228,7 @@ pub contract LostAndFound {
                     return 
                 }
 
-                self._redeemTicket(type: type, ticketID: key, receiver: receiver)
+                self.redeem(type: type, ticketID: key, receiver: receiver)
                 count = count + 1
             }
         }
@@ -239,19 +239,12 @@ pub contract LostAndFound {
                 receiver == nil || receiver!.address == self.redeemer: "receiver must match the redeemer of this shelf"
                 self.bins.containsKey(type.identifier): "no bin for provided type"
             }
-            self._redeemTicket(type: type, ticketID: ticketID, receiver: receiver)
-        }
-
-
-        // the internal redmption mechanic to join together the two different ways of redeeming (all of them or by ticketID)
-        access(self) fun _redeemTicket(type: Type, ticketID: UInt64, receiver: Capability, 
-        ) {
-            let binPublic = self.borrowBin(type: type)!
-            let ticket <- binPublic.withdrawTicket(ticketID: ticketID)
+            let bin = self.borrowBin(type: type)!
+            let ticket <- bin.withdrawTicket(ticketID: ticketID)
             ticket.withdraw(receiver: receiver)
             destroy ticket
         }
-
+   
         destroy () {
             destroy <- self.bins
         }

--- a/contracts/LostAndFound.cdc
+++ b/contracts/LostAndFound.cdc
@@ -33,12 +33,6 @@ pub contract LostAndFound {
         pub fun deposit(resource: @AnyResource)
     }
 
-    // Empty resource so we can unwrap ticket items for deposits to their corresponding receiver.
-    pub resource DummyResource {
-        init() { }
-    }
-
-    
     // Tickets are the resource that hold items to be redeemed. They carry with them:
     // - item: The Resource which has been deposited to be withdrawn/redeemed
     // - memo: An optional message to attach to this ticket
@@ -77,7 +71,7 @@ pub contract LostAndFound {
             pre {
                 receiver.address == self.redeemer: "receiver address and redeemer must match"
             }
-            
+
             var redeemableItem <- self.item <- nil
             
             if redeemableItem.isInstance(Type<@NonFungibleToken.NFT>()) && receiver.check<&{NonFungibleToken.CollectionPublic}>(){

--- a/contracts/LostAndFound.cdc
+++ b/contracts/LostAndFound.cdc
@@ -264,9 +264,7 @@ pub contract LostAndFound {
                 let oldValue <- self.shelves.insert(key: redeemer, <- create Shelf(redeemer: redeemer))
                 destroy oldValue
             }
-
             let ticket <- create Ticket(item: <-item, memo: memo, redeemer: redeemer)
-
             let shelf = self.borrowShelf(redeemer: redeemer)
             shelf.deposit(ticket: <-ticket)
         }

--- a/contracts/LostAndFound.cdc
+++ b/contracts/LostAndFound.cdc
@@ -268,13 +268,8 @@ pub contract LostAndFound {
         }
     }
 
-    pub resource interface ShelfManagerPublic {
-        pub fun deposit(redeemer: Address, item: @AnyResource, memo: String?)
-        pub fun borrowShelf(redeemer: Address): &LostAndFound.Shelf
-    }
-
     // ShelfManager is a light-weight wrapper to get our shelves into storage.
-    pub resource ShelfManager: ShelfManagerPublic {
+    pub resource ShelfManager {
         access(self) let shelves: @{Address: Shelf}
 
         init() {
@@ -303,8 +298,8 @@ pub contract LostAndFound {
         }
     }
 
-    pub fun borrowShelfManagerPublic(): &LostAndFound.ShelfManager{LostAndFound.ShelfManagerPublic} {
-        return self.account.getCapability<&LostAndFound.ShelfManager{LostAndFound.ShelfManagerPublic}>(LostAndFound.LostAndFoundPublicPath).borrow()!
+    pub fun borrowShelfManagerPublic(): &LostAndFound.ShelfManager {
+        return self.account.getCapability<&LostAndFound.ShelfManager>(LostAndFound.LostAndFoundPublicPath).borrow()!
     }
 
     init() {
@@ -313,6 +308,6 @@ pub contract LostAndFound {
 
         let manager <- create ShelfManager()
         self.account.save(<-manager, to: self.LostAndFoundStoragePath)
-        self.account.link<&LostAndFound.ShelfManager{LostAndFound.ShelfManagerPublic}>(self.LostAndFoundPublicPath, target: self.LostAndFoundStoragePath)
+        self.account.link<&LostAndFound.ShelfManager>(self.LostAndFoundPublicPath, target: self.LostAndFoundStoragePath)
     }
 }


### PR DESCRIPTION
- Bin should inplement BinPublic
- Clean up withdraw to single method, use optional reference from secure cadence
- let's get rid of dummy and make checker happy
- event parameter fix ( token -> redeemableItem
- Support for pre-secure cadence
- style
- Sync TicketPublic Interface
- get rid of setIsRedeemed
- formatting
- get rid of TicketPublic
- remove DummyResource
- redeem to single capability
- get rid of more interfaces
- some clean up
- get rid of _redeemTicket
- formatting & naming
- formatting & naming
