### PR TITLE
`DepositorLowBalance` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ For contracts that are going to deposit things often and don't want to send flow
 or for consumers who are not permitted to access flow tokens in this way, you can also use the LostAndFound Depositor
 to maintain a pool of tokens and deposit through it.
 
+When creating the depositor, there is an optional second argument for `lowBalanceThreshold`. The depositor will
+check the balance against this value and emit an event when the balance is less than this value.
+
 ### Initialize the depositor
 ```cadence
 import LostAndFound from 0xf8d6e0586b0a20c7
@@ -191,7 +194,7 @@ transaction {
     prepare(acct: AuthAccount) {
         if acct.borrow<&LostAndFound.Depositor>(from: LostAndFound.DepositorStoragePath) == nil {
             let flowTokenRepayment = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-            let depositor <- LostAndFound.createDepositor(flowTokenRepayment)
+            let depositor <- LostAndFound.createDepositor(flowTokenRepayment, lowBalanceThreshold: 10.0)
             acct.save(<-depositor, to: LostAndFound.DepositorStoragePath)
             acct.link<&LostAndFound.Depositor{LostAndFound.DepositorPublic}>(LostAndFound.DepositorPublicPath, target: LostAndFound.DepositorStoragePath)
         }

--- a/cadence/contracts/LostAndFound.cdc
+++ b/cadence/contracts/LostAndFound.cdc
@@ -430,7 +430,7 @@ pub contract LostAndFound {
         access(self) var lowBalanceThreshold: UFix64?
 
         access(self) fun checkForLowBalance(): Bool {
-            if  self.lowBalanceThreshold != nil &&self.balance() < self.lowBalanceThreshold! {
+            if  self.lowBalanceThreshold != nil &&self.balance() <= self.lowBalanceThreshold! {
                 emit DepositorBalanceLow(uuid: self.uuid, threshold: self.lowBalanceThreshold!, balance: self.balance())
                 return true
             }

--- a/cadence/transactions/Depositor/set_threshold.cdc
+++ b/cadence/transactions/Depositor/set_threshold.cdc
@@ -1,0 +1,13 @@
+import LostAndFound from "../../contracts/LostAndFound.cdc"
+import FungibleToken from "../../contracts/FungibleToken.cdc"
+import FlowToken from "../../contracts/FlowToken.cdc"
+
+transaction(newThreshold: UFix64?) {
+    let lfDepositor: &LostAndFound.Depositor
+
+    prepare(acct: AuthAccount) {
+        self.lfDepositor = acct.borrow<&LostAndFound.Depositor>(from: LostAndFound.DepositorStoragePath)!
+
+        self.lfDepositor.setLowBalanceThreshold(threshold: newThreshold)
+    }
+}

--- a/cadence/transactions/Depositor/setup.cdc
+++ b/cadence/transactions/Depositor/setup.cdc
@@ -3,11 +3,11 @@ import FungibleToken from "../../contracts/FungibleToken.cdc"
 import FlowToken from "../../contracts/FlowToken.cdc"
 
 
-transaction {
+transaction(lowBalanceThreshold: UFix64?) {
     prepare(acct: AuthAccount) {
         if acct.borrow<&LostAndFound.Depositor>(from: LostAndFound.DepositorStoragePath) == nil {
             let flowTokenRepayment = acct.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
-            let depositor <- LostAndFound.createDepositor(flowTokenRepayment)
+            let depositor <- LostAndFound.createDepositor(flowTokenRepayment, lowBalanceThreshold: lowBalanceThreshold)
             acct.save(<-depositor, to: LostAndFound.DepositorStoragePath)
             acct.link<&LostAndFound.Depositor{LostAndFound.DepositorPublic}>(LostAndFound.DepositorPublicPath, target: LostAndFound.DepositorStoragePath)
         }

--- a/cadence/transactions/Depositor/withdraw_tokens.cdc
+++ b/cadence/transactions/Depositor/withdraw_tokens.cdc
@@ -1,0 +1,15 @@
+import LostAndFound from "../../contracts/LostAndFound.cdc"
+import FungibleToken from "../../contracts/FungibleToken.cdc"
+import FlowToken from "../../contracts/FlowToken.cdc"
+
+
+transaction(amount: UFix64) {
+    let flowReceiver: &{FungibleToken.Receiver}
+    let lfDepositor: &LostAndFound.Depositor
+    prepare(acct: AuthAccount) {
+        self.flowReceiver = acct.borrow<&{FungibleToken.Receiver}>(from: /storage/flowTokenVault)!
+        self.lfDepositor = acct.borrow<&LostAndFound.Depositor>(from: LostAndFound.DepositorStoragePath)!
+
+        self.flowReceiver.deposit(from: <- self.lfDepositor.withdrawTokens(amount: amount))
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "emulator": "flow emulator -v -f flow.json --network emulator",
+    "deploy": "flow project deploy --network emulator",
+    "deploy:update": "npm run deploy -- --update"
   },
   "repository": {
     "type": "git",

--- a/test/common.js
+++ b/test/common.js
@@ -76,3 +76,16 @@ export const getEventFromTransaction = (txRes, eventType) => {
     }
     throw Error("did not find event in transaction")
 }
+
+export const composeCadenceTypeIdentifier = (addressWithOrWithoutPrefix, contractName, typeName) => {
+    const address = addressWithOrWithoutPrefix.startsWith('0x') ? addressWithOrWithoutPrefix.slice(2) : addressWithOrWithoutPrefix
+    return `A.${address}.${contractName}.${typeName}`
+}
+
+export const cadenceTypeIdentifierGenerator = (addressWithOrWithoutPrefix, contractName) => {
+    return (typeName) => composeCadenceTypeIdentifier(addressWithOrWithoutPrefix, contractName, typeName)
+}
+
+export const cadenceContractTypeIdentifierGenerator = (addressWithOrWithoutPrefix) => {
+    return (contractName) => cadenceTypeIdentifierGenerator(addressWithOrWithoutPrefix, contractName)
+}

--- a/test/common.js
+++ b/test/common.js
@@ -68,13 +68,15 @@ export const delay = (ms) =>
         setTimeout(resolve, ms)
     })
 
-export const getEventFromTransaction = (txRes, eventType) => {
+export const getEventFromTransaction = (txRes, eventType, throwError = true) => {
     for(let i = 0; i < txRes.events.length; i++) {
         if(txRes.events[i].type === eventType) {
             return txRes.events[i]
         }
     }
-    throw Error("did not find event in transaction")
+    if (throwError) {
+        throw Error("did not find event in transaction")
+    }
 }
 
 export const composeCadenceTypeIdentifier = (addressWithOrWithoutPrefix, contractName, typeName) => {


### PR DESCRIPTION
This PR adds an event and supporting infrastructure for an optional low balance threshold on the `Depositor`. 

If present, threshold is used to determine if a `DepositorLowBalance` event should be emitted. This occurs when tokens are deposited or withdrawn into the `Depositor`'s Flow token balance.

The low balance threshold is configurable at the time of `Depositor` creation or any time after.